### PR TITLE
Opimisation of unbreakable- and protectionblocks

### DIFF
--- a/src/main/java/stanuwu/fragmentcore2/Config.java
+++ b/src/main/java/stanuwu/fragmentcore2/Config.java
@@ -1,6 +1,7 @@
 package stanuwu.fragmentcore2;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -8,10 +9,16 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.Plugin;
 
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class Config implements CommandExecutor {
     private final Plugin plugin;
+
+    public static List<Material> protectedBlocks = new ArrayList<>();
+    public static List<Material> unbreakableBlocks = new ArrayList<>();
 
     public Config(Plugin plugin) {
         this.plugin = plugin;
@@ -24,6 +31,13 @@ public class Config implements CommandExecutor {
         }
         plugin.getConfig().options().copyDefaults(true);
         plugin.saveConfig();
+
+        for(String s : config.getStringList("fragmentcore.cannoning.protection-blocks")){
+            protectedBlocks.add(Material.valueOf(s.toUpperCase(Locale.ROOT)));
+        }
+        for(String s : config.getStringList("fragmentcore.cannoning.unbreakable-blocks")){
+            unbreakableBlocks.add(Material.valueOf(s.toUpperCase(Locale.ROOT)));
+        }
     }
 
     @Override

--- a/src/main/java/stanuwu/fragmentcore2/features/ProtectionBlocks.java
+++ b/src/main/java/stanuwu/fragmentcore2/features/ProtectionBlocks.java
@@ -9,6 +9,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityExplodeEvent;
+import stanuwu.fragmentcore2.Config;
 import stanuwu.fragmentcore2.FragmentCore2;
 
 import java.util.Iterator;
@@ -22,7 +23,7 @@ public class ProtectionBlocks implements Listener {
             World world = explosionLoc.getWorld();
             for (int y = -64; y <= 320; y++) {
                 Material materialType = world.getBlockAt(explosionLoc.getBlockX(), y, explosionLoc.getBlockZ()).getType();
-                if(FragmentCore2.config.getStringList("fragmentcore.cannoning.protection-blocks").contains(materialType.name().toLowerCase())){
+                if(Config.protectedBlocks.contains(materialType)){
                     isProtected = true;
                     break;
                 }
@@ -34,13 +35,13 @@ public class ProtectionBlocks implements Listener {
                 while(iterator.hasNext())
                 {
                     Block b = iterator.next();
-                    if(FragmentCore2.config.getStringList("fragmentcore.cannoning.unbreakable-blocks").contains(b.getType().name().toLowerCase())){
+                    if(Config.unbreakableBlocks.contains(b.getType())){
                         iterator.remove();
                         continue;
                     }
                     for (int y = -64; y <= 320; y++) {
                         Material materialType = world.getBlockAt(b.getX(), y, b.getZ()).getType();
-                        if(FragmentCore2.config.getStringList("fragmentcore.cannoning.protection-blocks").contains(materialType.name().toLowerCase())){
+                        if(Config.protectedBlocks.contains(materialType)){
                             iterator.remove();
                             break;
                         }


### PR DESCRIPTION
Reduce config calls by saving material list of unbreakable and protection blocks in memory.
Benchmarking:


![benchmark](https://github.com/FragmentMC/FragmentCore2/assets/79708538/b0517b05-ef2a-4a2a-a60f-ffc3e53762a1)
